### PR TITLE
Fix: Add missing comma in controls list to resolve SyntaxError

### DIFF
--- a/main.py
+++ b/main.py
@@ -439,7 +439,7 @@ def build_tela_estatisticas(page: Page):
                 tooltip="Retornar à tela inicial.",
                 bgcolor=obter_cor_do_tema_ativo("botao_principal_bg"),
                 color=obter_cor_do_tema_ativo("botao_principal_texto")
-            ) # <--- VÍRGULA ESTAVA FALTANDO AQUI, E FOI ADICIONADA NO PATCH ANTERIOR (subtarefa 18)
+            ), # <--- VÍRGULA ESTAVA FALTANDO AQUI, E FOI ADICIONADA NO PATCH ANTERIOR (subtarefa 18)
         ],
         scroll=ScrollMode.AUTO,
         alignment=MainAxisAlignment.CENTER,


### PR DESCRIPTION
A SyntaxError at the end of file indicated a missing comma. The comma was missing after an ElevatedButton in the controls list within the build_tela_estatisticas function, as pointed out by an existing comment. This commit adds the comma to fix the error.